### PR TITLE
Fix broken loading of local modules under Perl 5.26

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Changes for Debug::Client
 
+ - Fix build and test failures under Perl 5.26 when '.' is not in @INC (KENTNL, PR #7)
+
 0.30 2017-06-19
  - Merged PR #5 (Fixed test failure due to perl regression fix in 5.21.3), thanks @TBSliver.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install 1.08;
 
 name 'Debug-Client';

--- a/t/01-compile.t
+++ b/t/01-compile.t
@@ -8,7 +8,7 @@ use Test::More tests => 18;
 
 BEGIN {
 	use_ok('Debug::Client');
-	use_ok('t::lib::Debugger');
+	require_ok('./t/lib/Debugger.pm');
 
 	use_ok( 'Carp',           '1.20' );
 	use_ok( 'IO::Socket::IP', '0.21' );

--- a/t/08-io.t
+++ b/t/08-io.t
@@ -6,7 +6,10 @@ local $OUTPUT_AUTOFLUSH = 1;
 
 use Test::More tests => 12;
 use Test::Deep;
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 my ( $dir, $pid ) = start_script('t/eg/05-io.pl');
 my $path = $dir;

--- a/t/10-top_tail.t
+++ b/t/10-top_tail.t
@@ -7,7 +7,10 @@ local $OUTPUT_AUTOFLUSH = 1;
 use FindBin qw($Bin);
 use lib map "$Bin/$_", 'lib', '../lib';
 
-use t::lib::Top_Tail;
+BEGIN {
+  require "./t/lib/Top_Tail.pm";
+  t::lib::Top_Tail->import;
+};
 
 # run all the test methods
 Test::Class->runtests;

--- a/t/10-top_tail_old.t
+++ b/t/10-top_tail_old.t
@@ -10,7 +10,11 @@ local $| = 1;
 use Test::More tests => 5;
 use Test::Deep;
 use PadWalker;
-use t::lib::Debugger;
+
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 ok( start_script('t/eg/14-y_zero.pl'), 'start script' );
 

--- a/t/11-add.t
+++ b/t/11-add.t
@@ -9,7 +9,10 @@ local $| = 1;
 
 use Test::More tests => 10;
 use Test::Deep;
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 # Testing step_in (s) and show_line (.) on a simple script
 

--- a/t/13-return.t
+++ b/t/13-return.t
@@ -7,7 +7,10 @@ use warnings FATAL => 'all';
 # Turn on $OUTPUT_AUTOFLUSH
 local $| = 1;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 my ( $dir, $pid ) = start_script('t/eg/03-return.pl');
 

--- a/t/14-run.t
+++ b/t/14-run.t
@@ -7,7 +7,10 @@ use warnings FATAL => 'all';
 # Turn on $OUTPUT_AUTOFLUSH
 local $| = 1;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 my ( $dir, $pid ) = start_script('t/eg/02-sub.pl');
 

--- a/t/15-run_to_line.t
+++ b/t/15-run_to_line.t
@@ -7,7 +7,10 @@ use warnings FATAL => 'all';
 # Turn on $OUTPUT_AUTOFLUSH
 local $| = 1;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 my ( $dir, $pid ) = start_script('t/eg/02-sub.pl');
 

--- a/t/16-run_to_sub.t
+++ b/t/16-run_to_sub.t
@@ -7,7 +7,10 @@ use warnings FATAL => 'all';
 # Turn on $OUTPUT_AUTOFLUSH
 local $| = 1;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 my $pid = start_script('t/eg/02-sub.pl');
 

--- a/t/17-stepin.t
+++ b/t/17-stepin.t
@@ -13,7 +13,10 @@ plan( tests => 4 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/02-sub.pl');
 my $debugger;

--- a/t/18-stepout.t
+++ b/t/18-stepout.t
@@ -13,7 +13,10 @@ plan( tests => 4 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/02-sub.pl');
 my $debugger;

--- a/t/19-stepover.t
+++ b/t/19-stepover.t
@@ -13,7 +13,10 @@ plan( tests => 3 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/02-sub.pl');
 my $debugger;

--- a/t/20-get_value.t
+++ b/t/20-get_value.t
@@ -13,7 +13,10 @@ plan( tests => 6 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/02-sub.pl');
 my $debugger;

--- a/t/21-toggle_trace.t
+++ b/t/21-toggle_trace.t
@@ -13,7 +13,10 @@ plan( tests => 2 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/22-subnames.t
+++ b/t/22-subnames.t
@@ -13,7 +13,10 @@ plan( tests => 2 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/23-breakpoints.t
+++ b/t/23-breakpoints.t
@@ -13,7 +13,10 @@ plan( tests => 7 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/03-return.pl');
 my $debugger;

--- a/t/24-y_zero.t
+++ b/t/24-y_zero.t
@@ -13,7 +13,10 @@ plan( tests => 3 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/25-get_v_vars.t
+++ b/t/25-get_v_vars.t
@@ -13,7 +13,10 @@ plan( tests => 2 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/26-get_x_vars.t
+++ b/t/26-get_x_vars.t
@@ -13,7 +13,10 @@ plan( tests => 2 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/27-get_p_exp.t
+++ b/t/27-get_p_exp.t
@@ -13,7 +13,10 @@ plan( tests => 7 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/28-get_h_var.t
+++ b/t/28-get_h_var.t
@@ -13,7 +13,10 @@ plan( tests => 2 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/29-options.t
+++ b/t/29-options.t
@@ -13,7 +13,10 @@ plan( tests => 4 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/14-y_zero.pl');
 my $debugger;

--- a/t/40-test_1415-old.t
+++ b/t/40-test_1415-old.t
@@ -13,7 +13,10 @@ plan( tests => 12 );
 
 
 #Top
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 start_script('t/eg/test_1415.pl');
 my $debugger;

--- a/t/40-test_1415.t
+++ b/t/40-test_1415.t
@@ -7,7 +7,10 @@ local $OUTPUT_AUTOFLUSH = 1;
 use FindBin qw($Bin);
 use lib map "$Bin/$_", 'lib', '../lib';
 
-use t::lib::Test_1415;
+BEGIN {
+  require "./t/lib/Test_1415.pm";
+  t::lib::Test_1415->import();
+}
 
 # run all the test methods
 Test::Class->runtests;

--- a/t/99-perldb.t
+++ b/t/99-perldb.t
@@ -9,7 +9,10 @@ local $| = 1;
 
 use Test::More tests => 1;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 if (rc_file) {
 	diag('');

--- a/t/lib/Test_1415.pm
+++ b/t/lib/Test_1415.pm
@@ -7,7 +7,10 @@ use parent qw(Test::Class);
 use Test::More;
 use Test::Deep;
 
-use t::lib::Debugger;
+BEGIN {
+  require "./t/lib/Debugger.pm";
+  t::lib::Debugger->import;
+}
 
 # setup methods are run before every test method.
 sub load_debugger : Test(setup) {

--- a/t/lib/Top_Tail.pm
+++ b/t/lib/Top_Tail.pm
@@ -11,7 +11,8 @@ use Test::Deep;
 sub startup : Test(4) {
 	my $self = shift;
 
-	use_ok( 't::lib::Debugger');
+	require_ok('./t/lib/Debugger.pm');
+	t::lib::Debugger->import;
 	ok( start_script('t/eg/14-y_zero.pl'), 'start script' );
 	ok( $self->{debugger} = start_debugger(), 'start debugger' );
 	ok( $self->{debugger}->get, 'get debugger' );


### PR DESCRIPTION
Perl 5.26 breaks the implication that:
```perl
  use inc::Module::Install;
  use t::lib::Debugger;
```
Will load:
```
  ./inc/Module/Install.pm
  ./t/lib/Debugger.pm
```
Respectively, due to '.' ceasing to be in @INC

This fixes:
- Makefile.PL by re-inserting the '.' ( which is the only
  thing that works, due to Module::Install shenanigans ).
- Tests by replacing "use" statements with equivalent "require"
statements.

Some of the existing code ( eg: use_ok ) was already spurious and not
very smart, because calling ->import while being outside of BEGIN { }
has limited usefullness.

But this was left with the semantically equivalent code that retains
the loading of the relative path.

There are strategies that would be "nicer" than what I've done,
but they all wind up with you wanting to rename "Debugger.pm" to
something else, because:
```perl
  use lib "t/lib";
  use Debugger;
```
Is going to give people a much different impression from either
```
  use t::lib::Debugger
```
Or
```perl
  BEGIN {
    require "./t/lib/Debugger.pm";
    t::lib::Debugger->import();
  }
```
This closes https://github.com/PadreIDE/Debug-Client/issues/6